### PR TITLE
Fix layout duplication and move scooter pages

### DIFF
--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,10 +1,8 @@
-import Layout from "@/components/Layout";
-
 export default function DashboardPage() {
   return (
-    <Layout>
+    <>
       <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
       <p>Hier kommt dein Umsatz oder Rollerstatus rein …</p>
-    </Layout>
+    </>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,5 @@
-import Layout from "@/components/Layout";
-
 export default function Home() {
   return (
-    <Layout>
-      <h1 className="text-2xl font-bold">Willkommen bei Texvix sdda</h1>
-    </Layout>
+    <h1 className="text-2xl font-bold">Willkommen bei Texvix Admin</h1>
   );
 }

--- a/pages/scooters/[id].tsx
+++ b/pages/scooters/[id].tsx
@@ -1,5 +1,4 @@
 import { useRouter } from "next/router";
-import Layout from "@/components/Layout";
 import Link from "next/link";
 
 const dummyScooterData = {
@@ -37,16 +36,14 @@ export default function ScooterDetail() {
 
   if (!scooter) {
     return (
-      <Layout>
-        <div className="text-center py-10 text-red-500 text-lg font-semibold">
-          Kein Roller mit dieser ID gefunden.
-        </div>
-      </Layout>
+      <div className="text-center py-10 text-red-500 text-lg font-semibold">
+        Kein Roller mit dieser ID gefunden.
+      </div>
     );
   }
 
   return (
-    <Layout>
+    <>
       <div className="mb-6">
         <Link
           href="/scooters"
@@ -72,6 +69,6 @@ export default function ScooterDetail() {
           <div className="text-lg font-bold">{scooter.bookings}</div>
         </div>
       </div>
-    </Layout>
+    </>
   );
 }

--- a/pages/scooters/index.tsx
+++ b/pages/scooters/index.tsx
@@ -1,4 +1,3 @@
-import Layout from "@/components/Layout";
 import Link from "next/link";
 
 const scooters = [
@@ -15,7 +14,7 @@ const statusColor = {
 
 export default function ScooterOverview() {
   return (
-    <Layout>
+    <>
       <h1 className="text-2xl font-bold mb-4">Rollerübersicht</h1>
       <table className="w-full border text-sm bg-white shadow-sm rounded-md overflow-hidden">
         <thead className="bg-gray-100">
@@ -44,6 +43,6 @@ export default function ScooterOverview() {
           ))}
         </tbody>
       </table>
-    </Layout>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- move scooter pages into `pages/scooters`
- wrap pages only once with `Layout`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f08e1c5408327aa3b4c1090228ddd